### PR TITLE
Implement DeFi PoC frontend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,39 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { ThirdwebProvider } from 'thirdweb/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './App.css'
+import { TradeInput } from './components/TradeInput'
+import { PriceTable } from './components/PriceTable'
+import { Header } from './components/Header'
+import { BuyButton } from './components/BuyButton'
+import { useQuotes } from './hooks/useQuotes'
 
-function App() {
-  const [count, setCount] = useState(0)
+const queryClient = new QueryClient()
+
+function InnerApp() {
+  const [amount, setAmount] = useState(100)
+  const { data = [], dataUpdatedAt } = useQuotes(amount)
+  const best = data[0]
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div>
+      <Header />
+      <TradeInput amount={amount} setAmount={setAmount} />
+      <PriceTable data={data} updatedAt={dataUpdatedAt} />
+      <BuyButton row={best} />
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <ThirdwebProvider activeChain="sepolia">
+      <QueryClientProvider client={queryClient}>
+        <InnerApp />
+      </QueryClientProvider>
+    </ThirdwebProvider>
   )
 }
 
 export default App
+

--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -1,0 +1,32 @@
+import { Web3Button, useContract } from 'thirdweb/react'
+import { QuoteRow } from '../hooks/useQuotes'
+import { ethers } from 'ethers'
+
+const ROUTER_ADDRESS = '0x0000000000000000000000000000000000000000'
+const WETH = '0x5300000000000000000000000000000000000004'
+
+const abi = [
+  'function swapVia0x(bytes calldata swapCalldata, address buyToken, uint256 minOut) external payable'
+]
+
+interface Props {
+  row: QuoteRow | undefined
+}
+
+export const BuyButton = ({ row }: Props) => {
+  const { contract } = useContract(ROUTER_ADDRESS, abi)
+
+  if (!row) return null
+
+  return (
+    <Web3Button
+      contract={contract}
+      action={async (c) => {
+        await c.call('swapVia0x', [row.data, WETH, BigInt(row.buyAmount)])
+      }}
+    >
+      Buy
+    </Web3Button>
+  )
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,9 @@
+import { ConnectWallet } from 'thirdweb/react'
+
+export const Header = () => (
+  <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+    <h1>DeFi PoC</h1>
+    <ConnectWallet />
+  </header>
+)
+

--- a/src/components/PriceTable.tsx
+++ b/src/components/PriceTable.tsx
@@ -1,0 +1,43 @@
+import { QuoteRow } from '../hooks/useQuotes'
+
+interface Props {
+  data: QuoteRow[]
+  updatedAt: number | undefined
+}
+
+export const PriceTable = ({ data, updatedAt }: Props) => {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>DEX</th>
+          <th>Exec Price</th>
+          <th>LP Fee (bp)</th>
+          <th>Gas USD</th>
+          <th>Total USDC</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((r) => (
+          <tr key={r.dex}>
+            <td>{r.dex}</td>
+            <td>{r.price.toFixed(6)}</td>
+            <td>{r.lpFee.toFixed(2)}</td>
+            <td>{r.gasUsd.toFixed(2)}</td>
+            <td>{r.total.toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+      {updatedAt && (
+        <tfoot>
+          <tr>
+            <td colSpan={5} style={{ textAlign: 'right' }}>
+              updated {Math.floor((Date.now() - updatedAt) / 1000)}s ago
+            </td>
+          </tr>
+        </tfoot>
+      )}
+    </table>
+  )
+}
+

--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -1,0 +1,21 @@
+import { Dispatch, SetStateAction } from 'react'
+
+interface Props {
+  amount: number
+  setAmount: Dispatch<SetStateAction<number>>
+}
+
+export const TradeInput = ({ amount, setAmount }: Props) => {
+  return (
+    <div style={{ marginBottom: '1rem' }}>
+      <label>Sell Amount (USDC): </label>
+      <input
+        type="number"
+        value={amount}
+        onChange={(e) => setAmount(Number(e.target.value))}
+        min={0}
+      />
+    </div>
+  )
+}
+

--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query'
+import axios from 'axios'
+
+export interface QuoteRow {
+  dex: string
+  price: number
+  lpFee: number
+  gasUsd: number
+  total: number
+  data: string
+  buyAmount: string
+}
+
+const ETH_USD = 2000
+
+const DEXES = [
+  'Uniswap_V3',
+  'Uniswap_V2',
+  'SushiSwap',
+  'Balancer_V2',
+  'Curve'
+]
+
+const fetchQuoteForDex = async (amount: number, dex: string): Promise<QuoteRow | null> => {
+  const sellAmount = BigInt(Math.floor(amount * 1e6))
+  const url = 'https://sepolia.api.0x.org/swap/v1/quote'
+
+  try {
+    const res = await axios.get(url, {
+      params: {
+        sellToken: 'USDC',
+        buyToken: 'WETH',
+        sellAmount: sellAmount.toString(),
+        includedSources: dex
+      }
+    })
+
+    const q = res.data
+    const gasUsd = (Number(q.gas) * Number(q.gasPrice)) / 1e18 * ETH_USD
+    return {
+      dex,
+      price: Number(q.price),
+      lpFee: 0,
+      gasUsd,
+      total: Number(q.sellAmount) / 1e6 + gasUsd,
+      data: q.data,
+      buyAmount: q.buyAmount
+    }
+  } catch {
+    return null
+  }
+}
+
+export const useQuotes = (amount: number) => {
+  return useQuery({
+    queryKey: ['quotes', amount],
+    queryFn: async () => {
+      const rows = await Promise.all(
+        DEXES.map((d) => fetchQuoteForDex(amount, d))
+      )
+      const list = rows.filter(Boolean) as QuoteRow[]
+      return list.sort((a, b) => a.total - b.total).slice(0, 5)
+    },
+    refetchInterval: 30000
+  })
+}
+


### PR DESCRIPTION
## Summary
- integrate thirdweb provider and react-query
- create hooks for 0x swap quotes
- add simple components for header, trade input, price table and buy button
- wire them together in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849ba84afe88324982ad5a1549590e9